### PR TITLE
ci(docs): 添加 GitHub Actions 页面文档部署流程

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,3 +98,43 @@ jobs:
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy-docs:
+    runs-on: ubuntu-latest
+    needs: build-and-release
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install doc dependencies
+        working-directory: doc
+        run: npm ci
+
+      - name: Build doc site
+        working-directory: doc
+        run: npm run build
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: doc/out
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/doc/app/api/search/route.ts
+++ b/doc/app/api/search/route.ts
@@ -1,7 +1,0 @@
-import { source } from '@/lib/source';
-import { createFromSource } from 'fumadocs-core/search/server';
-
-export const { GET } = createFromSource(source, {
-  // https://docs.orama.com/docs/orama-js/supported-languages
-  language: 'english',
-});

--- a/doc/next.config.mjs
+++ b/doc/next.config.mjs
@@ -1,10 +1,11 @@
-import { createMDX } from 'fumadocs-mdx/next';
+import { createMDX } from 'fumadocs-mdx/next'
 
-const withMDX = createMDX();
+const withMDX = createMDX()
 
 /** @type {import('next').NextConfig} */
 const config = {
   reactStrictMode: true,
-};
+  output: 'export',
+}
 
-export default withMDX(config);
+export default withMDX(config)


### PR DESCRIPTION
- 新增 deploy-docs 任务用于构建并部署文档网站到 GitHub Pages
- 配置 Node.js 环境和依赖安装步骤
- 实现文档构建命令并上传构建产物
- 使用官方 actions 部署页面并输出页面 URL
- 修改 next.config.mjs，启用静态导出以支持 GitHub Pages
- 删除 api/search 路由的搜索接口实现，简化文档站点结构