### PR TITLE
feat(options): implement message-based navigation to options page

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -59,6 +59,13 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       chrome.sidePanel.open({ windowId })
     }
   }
+
+  if (message?.type === 'openOptionsPage' && typeof message.tab === 'string') {
+    chrome.tabs.create({
+      url: `options.html?tab=${message.tab}`,
+      active: true,
+    })
+  }
 })
 
 /**

--- a/src/utils/open-options.ts
+++ b/src/utils/open-options.ts
@@ -1,7 +1,4 @@
-/** 打开扩展 options 页（content script 中不要用 window.open，会被浏览器拦截） */
-export function openOptionsPage(tab: string): void {
-  void chrome.tabs.create({
-    url: `options.html?tab=${tab}`,
-    active: true,
-  })
+/** 打开扩展 options 页（content script 无 chrome.tabs 权限，需经 background 打开） */
+export function openOptionsPage(tab: string) {
+  chrome.runtime.sendMessage({ type: 'openOptionsPage', tab })
 }


### PR DESCRIPTION
- Added a message listener in the background script to handle opening the options page via a message.
- Refactored openOptionsPage utility to send a message instead of directly creating a tab, improving the separation of concerns.